### PR TITLE
feat: permitir duplicar invoice

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -237,6 +237,47 @@ export async function deleteInvoiceAction(formData: FormData) {
   redirect("/");
 }
 
+export async function duplicateInvoiceAction(formData: FormData) {
+  const invoiceId = asString(formData.get("invoiceId"));
+
+  if (!invoiceId) {
+    return;
+  }
+
+  const store = await readStore();
+  const currentInvoice = store.invoices.find((invoice) => invoice.id === invoiceId);
+
+  if (!currentInvoice) {
+    return;
+  }
+
+  const now = new Date().toISOString();
+  const newInvoiceId = crypto.randomUUID();
+  const duplicatedItems = currentInvoice.items.map((item) => ({
+    ...item,
+    id: crypto.randomUUID(),
+  }));
+  const total = duplicatedItems.reduce((sum, item) => sum + item.total, 0);
+
+  await saveInvoice({
+    ...currentInvoice,
+    id: newInvoiceId,
+    number: nextInvoiceNumber(store.invoices, currentInvoice.ownerId),
+    status: "draft",
+    items: duplicatedItems,
+    subtotal: total,
+    total,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  revalidatePath("/");
+  revalidatePath("/clients");
+  revalidatePath("/invoices/new");
+  revalidatePath(`/invoices/${invoiceId}`);
+  redirect(`/invoices/${newInvoiceId}/edit`);
+}
+
 export async function updateInvoiceStatusAction(formData: FormData) {
   const invoiceId = asString(formData.get("invoiceId"));
   const status = asString(formData.get("status")) as InvoiceStatus;

--- a/src/app/invoices/[id]/page.tsx
+++ b/src/app/invoices/[id]/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { deleteInvoiceAction, updateInvoiceStatusAction } from "@/app/actions";
+import {
+  deleteInvoiceAction,
+  duplicateInvoiceAction,
+  updateInvoiceStatusAction,
+} from "@/app/actions";
 import { Shell } from "@/components/shell";
 import { StatusPill } from "@/components/status-pill";
 import { formatCurrency, formatDate } from "@/lib/format";
@@ -102,6 +106,13 @@ export default async function InvoiceDetailPage({
               >
                 Abrir versão de impressão
               </Link>
+              <button
+                type="submit"
+                formAction={duplicateInvoiceAction}
+                className="rounded-xl border border-[#2c1973]/15 bg-white/92 px-5 py-3 text-sm font-semibold text-[#2c1973] shadow-[0_8px_24px_rgba(44,25,115,0.08)] transition hover:-translate-y-0.5 hover:border-[#2c1973]/35 hover:bg-[#2c1973] hover:text-white"
+              >
+                Duplicar invoice
+              </button>
             </div>
           </form>
 


### PR DESCRIPTION
### Motivation
- Suporte para reaproveitar invoices recorrentes conforme backlog item: permitir duplicar uma invoice existente para economizar tempo em faturamento mensal.

### Description
- Adiciona a server action `duplicateInvoiceAction` em `src/app/actions.ts` que clona uma invoice existente, gerando novo `id`, novo `number` via `nextInvoiceNumber`, novos `id`s para cada item, `status` inicial `draft` e novos timestamps (`createdAt`, `updatedAt`).
- Persiste a nova invoice com `saveInvoice`, revalida rotas relevantes com `revalidatePath` e redireciona para a tela de edição da nova invoice com `redirect(`/invoices/${newInvoiceId}/edit`)`.
- Atualiza a UI de detalhe em `src/app/invoices/[id]/page.tsx` para importar a nova action e expor um botão `Duplicar invoice` que dispara a action via `formAction`.

### Testing
- Executado `npm run lint` e o lint passou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e57ac80c048326b8fcfffbfe8f6b92)